### PR TITLE
setCanonicalRecord should check for this.canonicalState, not this.inv…

### DIFF
--- a/packages/ember-data/lib/system/relationships/state/belongs-to.js
+++ b/packages/ember-data/lib/system/relationships/state/belongs-to.js
@@ -34,8 +34,8 @@ BelongsToRelationship.prototype.setRecord = function(newRecord) {
 BelongsToRelationship.prototype.setCanonicalRecord = function(newRecord) {
   if (newRecord) {
     this.addCanonicalRecord(newRecord);
-  } else if (this.inverseRecord) {
-    this.removeCanonicalRecord(this.inverseRecord);
+  } else if (this.canonicalState) {
+    this.removeCanonicalRecord(this.canonicalState);
   }
   this.setHasData(true);
 };


### PR DESCRIPTION
…erseRecord

This commit adds the patch which is only added from Ember Data version 2.6 onwards (https://github.com/emberjs/data/commit/8400b9ddbce36f7d93c5b519eda974e46f612fd8) on version 1.13.12 which we are currently using.

// ... please delete this default text after reading

If this is your first PR to `ember-data`, you may want to read our [Contributor Guide](https://github.com/emberjs/data/blob/master/CONTRIBUTING.md).
